### PR TITLE
Fix katex block overflow on narrow devices

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,6 +7,13 @@
   <meta name="description" content="Description">
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">
+  <style>
+    .katex-display > .katex {
+      max-width: 100%;
+      overflow-x: auto;
+      overflow-y: hidden;
+    }
+  </style>
 </head>
 <body>
   <div id="app"></div>


### PR DESCRIPTION
### Before:
![localhost_8000_ (2)](https://user-images.githubusercontent.com/41495669/88686742-f7d4bc80-d129-11ea-83e4-9cc903854499.png)
### After:
![localhost_8000_ (1)](https://user-images.githubusercontent.com/41495669/88686805-0b802300-d12a-11ea-9d96-d5e99332e107.png)
